### PR TITLE
PGPRO-8706: Fix t_isspace(), etc., when datlocprovider=i and datctype…

### DIFF
--- a/tsparser.c
+++ b/tsparser.c
@@ -309,11 +309,14 @@ TParserInit(char *str, int len)
 	 */
 	if (prs->charmaxlen > 1)
 	{
-		Oid			collation = DEFAULT_COLLATION_OID;	/* TODO */
 		pg_locale_t mylocale = 0;		/* TODO */
 
 		prs->usewide = true;
-		if (lc_ctype_is_c(collation))
+#if PG_VERSION_NUM >= 160000
+		if (database_ctype_is_c)
+#else
+		if (lc_ctype_is_c(DEFAULT_COLLATION_OID))
+#endif
 		{
 			/*
 			 * char2wchar doesn't work for C-locale and sizeof(pg_wchar) could


### PR DESCRIPTION
…=C for 16+

See the commit f413941f41d370a7893caa3e6ed384b89a0577fd (Fix t_isspace(), etc., when datlocprovider=i and datctype=C.) in PostgreSQL 16+. A fix for previous major versions will be added later.