### PR TITLE
PGPRO-18082; PGPRO-15138: Following vanilla char2wchar() changes

### DIFF
--- a/tsparser.c
+++ b/tsparser.c
@@ -309,7 +309,11 @@ TParserInit(char *str, int len)
 	 */
 	if (prs->charmaxlen > 1)
 	{
+#if PG_VERSION_NUM >= 190000
+		locale_t mylocale = 0;		/* TODO */
+#else
 		pg_locale_t mylocale = 0;		/* TODO */
+#endif
 
 		prs->usewide = true;
 #if PG_VERSION_NUM >= 150000 || (defined(PGPRO_STD) && PG_VERSION_NUM >= 120000)


### PR DESCRIPTION
Caused by:
- 53cd0b71 (PostgreSQL) Change wchar2char() and char2wchar() to accept a locale_t.
- 3db3824d (pg_tsparser) First commit

Reviewed-by: Anton A. Melnikov <a.melnikov@postgrespro.ru>

Tags: pg_tsparser